### PR TITLE
Add auto-generated RSS feed for blog posts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,6 @@
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  site: 'https://rockwotj.com',
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/rss": "^4.0.15",
     "astro": "^2.0.11"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@astrojs/rss':
+        specifier: ^4.0.15
+        version: 4.0.15
       astro:
         specifier: ^2.0.11
         version: 2.10.15(@types/node@25.0.3)
@@ -49,6 +52,9 @@ packages:
   '@astrojs/prism@2.1.2':
     resolution: {integrity: sha512-3antim1gb34689GHRQFJ88JEo93HuZKQBnmxDT5W/nxiNz1p/iRxnCTEhIbJhqMOTRbbo5h2ldm5qSxx+TMFQA==}
     engines: {node: '>=16.12.0'}
+
+  '@astrojs/rss@4.0.15':
+    resolution: {integrity: sha512-uXO/k6AhRkIDXmRoc6xQpoPZrimQNUmS43X4+60yunfuMNHtSRN5e/FiSi7NApcZqmugSMc5+cJi8ovqgO+qIg==}
 
   '@astrojs/telemetry@2.1.1':
     resolution: {integrity: sha512-4pRhyeQr0MLB5PKYgkdu+YE8sSpMbHL8dUuslBWBIdgcYjtD1SufPMBI8pgXJ+xlwrQJHKKfK2X1KonHYuOS9A==}
@@ -1646,6 +1652,10 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-parser@5.3.6:
+    resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -2924,6 +2934,9 @@ packages:
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
+  piccolore@0.1.3:
+    resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3418,6 +3431,9 @@ packages:
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
@@ -3997,6 +4013,11 @@ snapshots:
   '@astrojs/prism@2.1.2':
     dependencies:
       prismjs: 1.30.0
+
+  '@astrojs/rss@4.0.15':
+    dependencies:
+      fast-xml-parser: 5.3.6
+      piccolore: 0.1.3
 
   '@astrojs/telemetry@2.1.1':
     dependencies:
@@ -5677,6 +5698,10 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fast-xml-parser@5.3.6:
+    dependencies:
+      strnum: 2.1.2
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -7291,6 +7316,8 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
+  piccolore@0.1.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -7895,6 +7922,8 @@ snapshots:
   strip-final-newline@3.0.0: {}
 
   strip-json-comments@2.0.1: {}
+
+  strnum@2.1.2: {}
 
   stubs@3.0.0: {}
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,7 +16,8 @@
       <span>Social:</span>
       <span><a href="https://github.com/rockwotj" rel="noopener noreferrer">GitHub</a>, <a
           href="https://twitter.com/rockwotj" rel="noopener noreferrer">Twitter</a>, <a
-          href="https://linkined.com/in/rockwotj" rel="noopener noreferrer">LinkedIn</a></span>
+          href="https://linkined.com/in/rockwotj" rel="noopener noreferrer">LinkedIn</a>, <a
+          href="/rss.xml" rel="noopener noreferrer">RSS</a></span>
     </p>
   </div>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,7 +16,7 @@
       <span>Social:</span>
       <span><a href="https://github.com/rockwotj" rel="noopener noreferrer">GitHub</a>, <a
           href="https://twitter.com/rockwotj" rel="noopener noreferrer">Twitter</a>, <a
-          href="https://linkined.com/in/rockwotj" rel="noopener noreferrer">LinkedIn</a>, <a
+          href="https://linkedin.com/in/rockwotj" rel="noopener noreferrer">LinkedIn</a>, <a
           href="/rss.xml" rel="noopener noreferrer">RSS</a></span>
     </p>
   </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,6 +3,7 @@ const LINKS = [
   {name: "Home", href: "/"},
   {name: "Blog", href: "/blog/"},
   {name: "Resume", href: "/resume/"},
+  {name: "RSS", href: "/rss.xml"},
 ];
 
 const currentPath = Astro.url.pathname;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,7 +3,6 @@ const LINKS = [
   {name: "Home", href: "/"},
   {name: "Blog", href: "/blog/"},
   {name: "Resume", href: "/resume/"},
-  {name: "RSS", href: "/rss.xml"},
 ];
 
 const currentPath = Astro.url.pathname;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,6 +16,7 @@ const { title } = Astro.props;
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width" />
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="alternate" type="application/rss+xml" title="Tyler Rockwood's Blog" href="/rss.xml" />
   <meta name="generator" content={Astro.generator} />
   <title>{title ? `${title} - ` : ''}Tyler Rockwood's Website</title>
 </head>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,0 +1,19 @@
+import rss from '@astrojs/rss';
+
+export async function get(context) {
+  const postImports = import.meta.glob('./blog/*.md', { eager: true });
+  const posts = Object.values(postImports)
+    .filter(post => post.frontmatter.title && !post.frontmatter.draft)
+    .sort((a, b) => new Date(b.frontmatter.date) - new Date(a.frontmatter.date));
+
+  return rss({
+    title: "Tyler Rockwood's Blog",
+    description: 'Technical writings about software engineering, databases, WebAssembly, and more.',
+    site: context.site,
+    items: posts.map(post => ({
+      title: post.frontmatter.title,
+      pubDate: new Date(post.frontmatter.date),
+      link: post.url,
+    })),
+  });
+}


### PR DESCRIPTION
Uses @astrojs/rss to generate an RSS feed at /rss.xml that
automatically includes all non-draft blog posts sorted by date.
Adds RSS autodiscovery link tag and navigation link.

https://claude.ai/code/session_01BWXfLczN5v3EcV1fK9VtP5