### PR TITLE
Update resume with ADP link, sub-bullets, and connector links

### DIFF
--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -30,11 +30,13 @@ import Layout from '../layouts/Layout.astro';
         Working within the Core Streaming engine on <a href="https://www.redpanda.com/blog/redpanda-25-1-iceberg-topics-ga" rel="noopener noreferrer">Iceberg Topics</a> and <a href="https://www.redpanda.com/blog/cloud-topics-streaming-data-object-storage" rel="noopener noreferrer">Cloud Topics</a>.
       </li>
       <li>
-        Built a number of strategic connectors for Redpanda Connect:
-        <a href="https://www.redpanda.com/blog/fast-simple-data-ingestion-snowflake-connector" rel="noopener noreferrer">Snowflake</a>,
-        <a href="https://www.redpanda.com/blog/redpanda-connect-apache-iceberg-output" rel="noopener noreferrer">Iceberg</a>,
-        <a href="https://docs.redpanda.com/redpanda-connect/plugins/about/" rel="noopener noreferrer">FFI plugins</a>,
-        and <a href="https://www.redpanda.com/blog/multi-language-redpanda-connect-plugins" rel="noopener noreferrer">dynamic gRPC plugins</a>.
+        Built a number of strategic connectors for Redpanda Connect.
+        <ul>
+          <li><a href="https://www.redpanda.com/blog/fast-simple-data-ingestion-snowflake-connector" rel="noopener noreferrer">Snowflake connector</a></li>
+          <li><a href="https://www.redpanda.com/blog/redpanda-connect-apache-iceberg-output" rel="noopener noreferrer">Iceberg connector</a></li>
+          <li><a href="https://docs.redpanda.com/redpanda-connect/plugins/about/" rel="noopener noreferrer">FFI plugins</a></li>
+          <li><a href="https://www.redpanda.com/blog/multi-language-redpanda-connect-plugins" rel="noopener noreferrer">Dynamic gRPC plugins</a></li>
+        </ul>
       </li>
     </ul>
     <h4>OpenAI</h4>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -20,13 +20,21 @@ import Layout from '../layouts/Layout.astro';
     <p class="subheading">Principle Software Engineer | July, 2024 - Current</p>
     <ul>
       <li>
-        Helping define and make real the Agentic Data Plane.
+        Helping define and make real the <a href="https://www.redpanda.com/blog/agentic-data-plane-adp" rel="noopener noreferrer">Agentic Data Plane</a>.
+        <ul>
+          <li>Aligned teams and provided base components around observability for the ADP.</li>
+          <li>Designed and built fine-grained authorization primitives for the ADP.</li>
+        </ul>
       </li>
       <li>
-        Working within the Core Streaming engine on Iceberg Topics and Cloud Topics.
+        Working within the Core Streaming engine on <a href="https://www.redpanda.com/blog/redpanda-25-1-iceberg-topics-ga" rel="noopener noreferrer">Iceberg Topics</a> and <a href="https://www.redpanda.com/blog/cloud-topics-streaming-data-object-storage" rel="noopener noreferrer">Cloud Topics</a>.
       </li>
       <li>
-        Built a number of stategic connectors for Redpanda Connect.
+        Built a number of strategic connectors for Redpanda Connect:
+        <a href="https://www.redpanda.com/blog/fast-simple-data-ingestion-snowflake-connector" rel="noopener noreferrer">Snowflake</a>,
+        <a href="https://www.redpanda.com/blog/redpanda-connect-apache-iceberg-output" rel="noopener noreferrer">Iceberg</a>,
+        <a href="https://docs.redpanda.com/redpanda-connect/plugins/about/" rel="noopener noreferrer">FFI plugins</a>,
+        and <a href="https://www.redpanda.com/blog/multi-language-redpanda-connect-plugins" rel="noopener noreferrer">dynamic gRPC plugins</a>.
       </li>
     </ul>
     <h4>OpenAI</h4>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -38,6 +38,7 @@ import Layout from '../layouts/Layout.astro';
         <ul>
           <li><a href="https://www.redpanda.com/blog/fast-simple-data-ingestion-snowflake-connector" rel="noopener noreferrer">Snowflake connector</a></li>
           <li><a href="https://www.redpanda.com/blog/redpanda-connect-apache-iceberg-output" rel="noopener noreferrer">Iceberg connector</a></li>
+          <li><a href="https://www.redpanda.com/blog/cdc-connectors-real-time-data-streaming" rel="noopener noreferrer">CDC connectors</a></li>
           <li><a href="https://docs.redpanda.com/redpanda-connect/plugins/about/" rel="noopener noreferrer">FFI plugins</a></li>
           <li><a href="https://www.redpanda.com/blog/multi-language-redpanda-connect-plugins" rel="noopener noreferrer">Dynamic gRPC plugins</a></li>
         </ul>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -30,7 +30,7 @@ import Layout from '../layouts/Layout.astro';
         Working within the Core Streaming engine on <a href="https://www.redpanda.com/blog/redpanda-25-1-iceberg-topics-ga" rel="noopener noreferrer">Iceberg Topics</a> and <a href="https://www.redpanda.com/blog/cloud-topics-streaming-data-object-storage" rel="noopener noreferrer">Cloud Topics</a>.
         <ul>
           <li>Built a Parquet writer library and defined the behavior for schema management in Iceberg Topics.</li>
-          <li>Helped accelerate Cloud Topics development by building a production-grade LSM tree based on LevelDB with optimizations for metadata management.</li>
+          <li>Helped accelerate Cloud Topics development by building a production-grade LSM tree based on LevelDB with optimizations for metadata management (patented).</li>
         </ul>
       </li>
       <li>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -30,7 +30,7 @@ import Layout from '../layouts/Layout.astro';
         Working within the Core Streaming engine on <a href="https://www.redpanda.com/blog/redpanda-25-1-iceberg-topics-ga" rel="noopener noreferrer">Iceberg Topics</a> and <a href="https://www.redpanda.com/blog/cloud-topics-streaming-data-object-storage" rel="noopener noreferrer">Cloud Topics</a>.
         <ul>
           <li>Built a Parquet writer library and defined the behavior for schema management in Iceberg Topics.</li>
-          <li>Helped accelerate Cloud Topics development by building a production-grade general-purpose LSM tree for metadata management with novel optimizations (patented).</li>
+          <li>Helped accelerate Cloud Topics development by building a production-grade general-purpose LSM tree for metadata management (patented).</li>
         </ul>
       </li>
       <li>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -28,6 +28,10 @@ import Layout from '../layouts/Layout.astro';
       </li>
       <li>
         Working within the Core Streaming engine on <a href="https://www.redpanda.com/blog/redpanda-25-1-iceberg-topics-ga" rel="noopener noreferrer">Iceberg Topics</a> and <a href="https://www.redpanda.com/blog/cloud-topics-streaming-data-object-storage" rel="noopener noreferrer">Cloud Topics</a>.
+        <ul>
+          <li>Built a Parquet writer library and defined the behavior for schema management in Iceberg Topics.</li>
+          <li>Helped accelerate Cloud Topics development by building a production-grade LSM tree based on LevelDB with optimizations for metadata management.</li>
+        </ul>
       </li>
       <li>
         Built a number of strategic connectors for Redpanda Connect.

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -30,7 +30,7 @@ import Layout from '../layouts/Layout.astro';
         Working within the Core Streaming engine on <a href="https://www.redpanda.com/blog/redpanda-25-1-iceberg-topics-ga" rel="noopener noreferrer">Iceberg Topics</a> and <a href="https://www.redpanda.com/blog/cloud-topics-streaming-data-object-storage" rel="noopener noreferrer">Cloud Topics</a>.
         <ul>
           <li>Built a Parquet writer library and defined the behavior for schema management in Iceberg Topics.</li>
-          <li>Helped accelerate Cloud Topics development by building a production-grade LSM tree based on LevelDB with optimizations for metadata management (patented).</li>
+          <li>Helped accelerate Cloud Topics development by building a production-grade general-purpose LSM tree for metadata management with novel optimizations (patented).</li>
         </ul>
       </li>
       <li>


### PR DESCRIPTION
- Link "Agentic Data Plane" to Alex's blog announcement
- Add sub-bullets for observability alignment and fine-grained authorization work on ADP
- Link "Iceberg Topics" and "Cloud Topics" to their respective blog posts
- Link connectors to Snowflake blog, Iceberg connector blog, FFI plugin docs, and dynamic gRPC plugins blog

https://claude.ai/code/session_01Ta7KskkPhPJ8RdmeCdK2BT